### PR TITLE
Update server.py

### DIFF
--- a/captum/insights/attr_vis/server.py
+++ b/captum/insights/attr_vis/server.py
@@ -108,7 +108,6 @@ def start_server(
 
     global port
     if port is None:
-        os.environ["WERKZEUG_RUN_MAIN"] = "true"  # hides starting message
         if not debug:
             log = logging.getLogger("werkzeug")
             log.disabled = True


### PR DESCRIPTION
With Werkzeug 2.1.0, setting the environment variable `WERKZEUG_RUN_MAIN` results in `KeyError: 'WERKZEUG_SERVER_FD'`. `WERKZEUG_RUN_MAIN` is used by Werkzeug internally and is not supposed to be set by external libraries. Therefore, removed `os.environ["WERKZEUG_RUN_MAIN"] = "true"`.

Pointed out by: @jeremyfix

See:
- https://github.com/pallets/werkzeug/issues/2361
- https://github.com/pytorch/captum/issues/1127